### PR TITLE
Change package name | README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Types for yt-dlp.
 ## Installation
 
 ```shell
-pip install types-yt-dlp
+pip install yt-dlp-types
 ```
 
 ```shell
-poetry add types-yt-dlp
+poetry add yt-dlp-types
 ```


### PR DESCRIPTION
On [pypi.org](https://pypi.org/project/yt-dlp-types/) the package is name `yt-dlp-types` and not `types-yt-dlp`